### PR TITLE
Add CollectionType to Folder view

### DIFF
--- a/source/GeneralMetadata.brs
+++ b/source/GeneralMetadata.brs
@@ -863,7 +863,8 @@ Function getShortDescriptionLine2(i as Object, mode as String) as String
 	else if i.MediaType = "Video" Then
 
 		if i.ProductionYear <> invalid then return tostr(i.ProductionYear)
-
+	else if i.Type = "CollectionFolder" Then
+		return tostr(i.CollectionType)
 	end If
 
 	return ""


### PR DESCRIPTION
Allow the folder view to show the type each folder is designated. Makes use of the otherwise empty line in a useful way.