### PR TITLE
Add Type to Folder view

### DIFF
--- a/source/GeneralMetadata.brs
+++ b/source/GeneralMetadata.brs
@@ -864,9 +864,11 @@ Function getShortDescriptionLine2(i as Object, mode as String) as String
 
 		if i.ProductionYear <> invalid then return tostr(i.ProductionYear)
 
+	else if i.Type = "CollectionFolder" Then
+		return tostr(i.CollectionType)
+	else
+		return i.Type
 	end If
-
-	return ""
 
 End Function
 


### PR DESCRIPTION
Knowing the type each Folder is was missing. This makes use of the otherwise unused 2nd description line