### PR TITLE
Add a 2nd description for folder view

### DIFF
--- a/source/GeneralMetadata.brs
+++ b/source/GeneralMetadata.brs
@@ -864,9 +864,11 @@ Function getShortDescriptionLine2(i as Object, mode as String) as String
 
 		if i.ProductionYear <> invalid then return tostr(i.ProductionYear)
 
+	else if i.Type = "CollectionFolder" Then
+		return i.CollectionType
+	else
+		return i.Type
 	end If
-
-	return ""
 
 End Function
 


### PR DESCRIPTION
In regards to the folder view line on the homescreen. If item type is a collection folder it should show the collection type, otherwise it should show the item type as the second description line, rather than just the single line description of the folders name.