### PR TITLE
Add 2nd description line to items

### DIFF
--- a/source/GeneralMetadata.brs
+++ b/source/GeneralMetadata.brs
@@ -864,9 +864,13 @@ Function getShortDescriptionLine2(i as Object, mode as String) as String
 
 		if i.ProductionYear <> invalid then return tostr(i.ProductionYear)
 
+	else if i.Type = "CollectionFolder" Then
+		return i.CollectionType
+	else if i.Type = "Audio" Then
+		return i.Artists[0]
+	else
+		return i.Type
 	end If
-
-	return ""
 
 End Function
 


### PR DESCRIPTION
The 2nd description line is under utilized. CollectionType now shows on Folder view for collections, Artist playing now appears on audio view under currently playing song, Makes it clear if an item is a folder, or a book, or anything now.