### PR TITLE
Correct screen title cutoff

### DIFF
--- a/source/ViewController.brs
+++ b/source/ViewController.brs
@@ -1687,15 +1687,16 @@ Sub vcUpdateScreenProperties(screen)
     else if screenType = "roSearchScreen" then
         if enableBreadcrumbs then
             screen.Screen.SetBreadcrumbText(bread1, bread2)
-        end if
-    else if screenType = "roListScreen" then
-	
-		' SetBreadcrumbText is not available on legacy devices
-		if bread2 <> invalid then screen.Screen.SetTitle(bread2)
-		
+        end if	
     else if screenType = "roListScreen" OR screenType = "roKeyboardScreen" OR screenType = "roParagraphScreen" then
         if enableBreadcrumbs then
-            screen.Screen.SetTitle(bread2)
+            if bread2 <> invalid
+		title = bread2
+		if title.len() > 37 then
+			title = left(bread2,37) + "..."
+		end if
+		screen.Screen.SetTitle(title)
+	    end if
         end if
     else
         Debug("Not sure what to do with breadcrumbs on screen type: " + tostr(screenType))


### PR DESCRIPTION
the screen.settitle does not provide a cut-off and ellipsis when it is over size. this must be done manually then applied to screen.settitle.