### PR TITLE
Add flac to mkv containers directplay

### DIFF
--- a/source/capabilities.brs
+++ b/source/capabilities.brs
@@ -49,6 +49,10 @@ Function getDirectPlayProfiles()
             mkvAudio = mkvAudio + ",dca"
         end if
 
+	if CheckMinimumVersion(versionArr, [5, 3]) then
+		mkvAudio = mkvAudio + ",flac"
+	end if
+	
         profiles.push({
 			Type: "Video"
 			Container: "mkv"


### PR DESCRIPTION
Flac can be directplayed and will be decoded as PCM audio. This is acceptable to transcoding to AAC.