### PR TITLE
Allow movie/tv episode deletion from UI

### DIFF
--- a/source/GeneralMetadata.brs
+++ b/source/GeneralMetadata.brs
@@ -205,6 +205,7 @@ Function getMetadataFromServerItem(i as Object, imageType as Integer, primaryIma
 	metaData.MediaSources = i.MediaSources
 	metaData.People = i.People
 	metaData.CollectionType = i.CollectionType
+	metaData.CanDelete = i.CanDelete
 	
 	metaData.ChannelId = i.ChannelId
 	metaData.StartDate = i.StartDate

--- a/source/PosterScreen.brs
+++ b/source/PosterScreen.brs
@@ -251,6 +251,16 @@ Sub posterSeriesOptionsDialog()
 
 	dlg.SetButton("cast", "Cast & Crew")
 
+    ' TODO(jpr): should we also give option to delete the entire series/season?
+    status = m.contentArray[m.focusedList]
+    itemToDelete = status.content[status.focusedIndex]
+    ' TODO(jpr): there is a UI bug that shows a season to the user even if
+    ' there are no episodes in it. In this case, we won't have a valid item.
+    if itemToDelete <> invalid and itemToDelete.CanDelete = true then
+        dlg.itemToDelete = itemToDelete
+        dlg.SetButton("delete", "Delete item")
+    end if
+
 	dlg.item = m.Item
 	dlg.parentScreen = m
 
@@ -278,10 +288,19 @@ Function handleSeriesOptionsButton(command, data) As Boolean
         m.ViewController.InitializeOtherScreen(newScreen, [item.Title, "Cast & Crew"])
 		newScreen.Show()
         return true
-    else if command = "close" then
+  else if command = "delete" then
+    deleteDialog = createDeleteItemConfirmationDialog(m.itemToDelete.id)
+    deleteDialog.show(true)
+    deletedSuccessfully = deleteDialog.ItemDeletedSuccessfully
+    if deletedSuccessfully then
+      ' Item was deleted successfully, so let's reload the list
+      screen.Show()
+    end if
+    return true
+  else if command = "close" then
 		m.Screen.Close()
         return true
-    end if
+  end if
 	
     return false
 

--- a/source/TvScreen.brs
+++ b/source/TvScreen.brs
@@ -95,7 +95,7 @@ Function getTvLibraryRowScreenUrl(row as Integer, id as String) as String
 		url = url  + "/Users/" + HttpEncode(getGlobalVar("user").Id) + "/Items?recursive=true"
 
 		query.AddReplace("IncludeItemTypes", "Series")
-		query.AddReplace("fields", "Overview")
+		query.AddReplace("fields", "Overview,CanDelete")
 		query.AddReplace("ParentId", m.parentId)
 		query.AddReplace("ImageTypeLimit", "1")
 		
@@ -127,7 +127,7 @@ Function getTvLibraryRowScreenUrl(row as Integer, id as String) as String
 		
 	else if row = 2
 		' Tv next up
-		url = url  + "/Shows/NextUp?fields=Overview"
+		url = url  + "/Shows/NextUp?fields=Overview,CanDelete"
 
 		query.AddReplace("userid", getGlobalVar("user").Id)
 		query.AddReplace("SortBy", "SortName")
@@ -215,7 +215,7 @@ Function getTvSeasonUrl(row as Integer, seasonId as String) as String
 	userId = getGlobalVar("user").Id
 
 	url = url + "&userId=" + userId
-	url = url + "&fields=PrimaryImageAspectRatio,Overview"
+	url = url + "&fields=PrimaryImageAspectRatio,Overview,CanDelete"
 
 	return url
 
@@ -299,7 +299,7 @@ Function getTvGenreScreenUrl(row as Integer, id as String) as String
     ' Query
     query = {
         IncludeItemTypes: "Series"
-        fields: "Overview"
+        fields: "Overview,CanDelete"
         sortby: "SortName"
         sortorder: "Ascending",
 		genres: genre,
@@ -360,7 +360,7 @@ Function getTvAlphabetScreenUrl(row as Integer, id as String) as String
     ' Query
     query = {
         IncludeItemTypes: "Series"
-        fields: "Overview"
+        fields: "Overview,CanDelete"
         sortby: "SortName"
         sortorder: "Ascending",
 		ImageTypeLimit: "1"

--- a/source/VideoSpringboardScreen.brs
+++ b/source/VideoSpringboardScreen.brs
@@ -537,6 +537,10 @@ Sub springboardShowMoreDialog(item)
         dlg.SetButton("specials", "Special features")
     end if
 
+    if item.CanDelete = true then
+        dlg.SetButton("delete", "Delete")
+    end if
+
 	dlg.item = item
 	dlg.parentScreen = m
 
@@ -574,6 +578,18 @@ Function handleMoreOptionsButton(command, data) As Boolean
 		newScreen.ScreenName = "Chapters" + itemId
         m.ViewController.InitializeOtherScreen(newScreen, [item.Title, "Special Features"])
 		newScreen.Show()
+        return true
+    else if command = "delete" then
+        deleteDialog = createDeleteItemConfirmationDialog(itemId)
+        deleteDialog.show(true)
+        deletedSuccessfully = deleteDialog.ItemDeletedSuccessfully
+        if deletedSuccessfully then
+          ' Item was deleted successfully, so let's pop out of the detail view
+          ' TODO(jpr): figure out how to refresh TV episode list upon successful
+          ' deletion via the 'more' delete menu (as opposed to the options menu)
+          m.screen.close()
+          m.viewcontroller.popscreen(screen)
+        end if
         return true
     else if command = "cast" then
         newScreen = createPeopleScreen(m.ViewController, item)


### PR DESCRIPTION
I was getting tired of manually removing files via my computer so I went ahead and built the functionality to delete items in a couple places:

- TV episodes from the 'options' menu (note that this is technically the 'series options' screen, but it actually only pops up if you have an episode highlighted so I hijacked it for my purposes).
- TV episodes and movies by adding another entry to the 'more' menu within the VideoSpringboard

Note that Live TV recordings already had a delete capability, so I didn't touch that (nor did I refactor its codepath to merge the two strategies). I also didn't look into adding 'CanDelete' fetching/parsing and subsequent 'delete' capabilities for other media types (e.g. music). That's not in my use case, so I'm not familiar with what else might need to be delete-able. I also got a bit scared by how many places I would have had to custom add the 'CanDelete' field during HTTP requests, and decided to leave it for now.

This is the only Roku dev I've done to date, so please let me know if anything is non-standard, or especially if it's just plain bad. I've based most of the code on similar examples within the Emby.Roku and Emby repos.