### PR TITLE
Allow server to send text as messages to pop-up dialogs

### DIFF
--- a/source/ViewController.brs
+++ b/source/ViewController.brs
@@ -1040,13 +1040,14 @@ Function ProcessApplicationSetText() As Boolean
 
     screen = GetViewController().screens.Peek()
 
+    value = firstOf(m.request.query["String"], "")
     if type(screen.SetText) = "roFunction" then
-	
-        value = firstOf(m.request.query["String"], "")
         NowPlayingManager().textFieldContent = value
-        screen.SetText(value, true)
-
-	end if
+    else
+	' pop up a dialog for server messages on
+        ' screens which lack the settext function
+        createDialog("Message from the server", strReplace(tostr(value),"+"," "), "OK", true)
+    end if
 
     m.simpleOK("")
     return true


### PR DESCRIPTION
This feature is not fully functioning. It will only work on screens which are text oriented. Presently none are, so this feature isnt working fully. With this you can pop up a dialog on any screen, even over the videoplayer and display the messages sent from the server.