### PR TITLE
Fix flickering "Now Playing" display

### DIFF
--- a/source/AudioPlayer.brs
+++ b/source/AudioPlayer.brs
@@ -179,10 +179,8 @@ Sub audioPlayerReportPlayback(action as String)
 End Sub
 
 Sub audioPlayerCleanup()
-    m.Stop()
-    m.timelineTimer = invalid
-    fn = function() :m.AudioPlayer = invalid :end function
-    fn()
+	m.reportPlayback("stop")
+	m.Stop()
 End Sub
 
 Sub audioPlayerPlay()


### PR DESCRIPTION
This fixes the flickering between theme song and what is playing.

http://emby.media/community/index.php?/topic/15708-theme-music-reporting-being-played-when-its-finished/

See the above thread for more information.