### PR TITLE
videoplayer - fix "double" stop reporting

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -384,8 +384,8 @@ Function videoPlayerHandleMessage(msg) As Boolean
 			
 			if m.changeStream = false then 
 				m.playState = "stopped"
-				m.ReportPlayback("stop")
-				m.UpdateNowPlaying()
+				'm.ReportPlayback("stop")
+				'm.UpdateNowPlaying()
 			else
 				if m.IsTranscoded then m.StopTranscoding()
 			end if
@@ -397,8 +397,8 @@ Function videoPlayerHandleMessage(msg) As Boolean
             Debug("MediaPlayer::playVideo::VideoScreenEvent::isFullResult: position -> " + tostr(m.lastPosition))
             m.progressTimer.Active = false
 			m.playState = "stopped"
-			m.ReportPlayback("stop")
-            m.UpdateNowPlaying()
+			'm.ReportPlayback("stop")
+			'm.UpdateNowPlaying()
 			m.isPlayed = true
 
         else if msg.GetType() = 31 then


### PR DESCRIPTION
When playing video, the roku will issue two stops every time you stop a video. The recent activity on the server shows two stops at near the exact same millisecond. The reason is the partialresult and fullresult arent the last result. The isScreenClosed is the last. So if you have stops and reporting within the partialresult and fullresult you are being redundant. The isScreenClosed event will handle that. Hope you understand. :)