### PR TITLE
Allow BIF use on transcodes

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -215,9 +215,10 @@ Function videoPlayerCreateVideoPlayer(item, playOptions)
 	if m.IsTranscoded then
 		m.playMethod = "Transcode"	
 	else
-		addBifInfo(videoItem)
 		m.playMethod = "DirectStream"
 	end if
+
+	addBifInfo(videoItem)
 	
 	m.canSeek = videoItem.StreamInfo.CanSeek
 	


### PR DESCRIPTION
Here is the corresponding fix for the roku app to allow transcoded HLS streams to use BIF trick-play