### PR TITLE
Fix Crashing of LiveTV

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -139,9 +139,6 @@ Sub videoPlayerShow()
 		item = m.Context[m.CurIndex]
 		if item.PlayOptions <> invalid
 			m.PlayOptions = item.PlayOptions
-			if m.PlayOptions = invalid
-				m.PlayOptions = {}
-			end if
 		else
 			m.PlayOptions = {}
 		end if

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -137,15 +137,15 @@ Sub videoPlayerShow()
 
 	else
 		item = m.Context[m.CurIndex]
-		
-		m.PlayOptions = item.PlayOptions
-		
-		if m.PlayOptions = invalid
-		    m.PlayOptions = {}
-		end if	
-		
-        m.Screen = m.CreateVideoPlayer(item, m.PlayOptions)
-		
+		if item.PlayOptions <> invalid
+			m.PlayOptions = item.PlayOptions
+			if m.PlayOptions = invalid
+				m.PlayOptions = {}
+			end if
+		else
+			m.PlayOptions = {}
+		end if
+		m.Screen = m.CreateVideoPlayer(item, m.PlayOptions)
     end if
 
 	m.changeStream = false


### PR DESCRIPTION
The problem is item.PlayOptions may be invalid

m.PlayOptions = Item.PlayOptions

The top piece of code CANNOT be used if item.playoptions is invalid. The right side of an = statement cannot be a variable with the value of invalid. You need to check for this first, then if it isnt invalid allow the rest of the code to run. This corrects the problem and liveTV no longer crashes upon playing.