### PR TITLE
Fix syntax errors

### DIFF
--- a/source/appMain.brs
+++ b/source/appMain.brs
@@ -172,7 +172,7 @@ Sub initGlobals()
     ' number increased, starting with 8.
     if left(modelNumber,1) = "4" and major >=5 then
 	GetGlobalAA().AddReplace("maxRefFrames", 15)
-    elseif major >= 4 then
+    else if major >= 4 then
         GetGlobalAA().AddReplace("maxRefFrames", 8)
     else
         GetGlobalAA().AddReplace("maxRefFrames", 5)

--- a/source/connectionmanager/WakeOnLan.brs
+++ b/source/connectionmanager/WakeOnLan.brs
@@ -40,7 +40,7 @@ Sub mgrSendWol(machineID as String, screen=invalid)
         ' only send the broadcast 5 (numReqToSend) times per requested mac address
         WOLcounterKey = "WOLCounter" + tostr(mac)
         if GetGlobalAA().lookup(WOLcounterKey) = invalid then GetGlobalAA().AddReplace(WOLcounterKey, 0)
-        GetGlobalAA()[WOLcounterKey] = GetGlobalAA().[WOLcounterKey]  + 1
+        GetGlobalAA()[WOLcounterKey] = GetGlobalAA()[WOLcounterKey] + 1
 
         ' return if we have already send enough requests
         if GetGlobalAA()[WOLcounterKey] > numReqToSend then 


### PR DESCRIPTION
- according to the specification, "elseif" is also allowed, but the roku syntax checker (eclipse plugin) wants "else if"
- according to the brightscript spec, the dot operator can be used on an associative array to access the value for a fixed literal (known at compile time), while the array operator (square brackets) can also take variables as a key.  But from my understanding there is no valid combination of a dot operator immediately followed by the array operator.